### PR TITLE
INFRA-8074 Update docker registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 service := requestbin
 tag := red
 
-main_image := registry:5000/jenkins/$(service):$(tag)
+main_image := registry.internal.telnyx.com/jenkins/$(service):$(tag)
 docker_build_args = \
 	--build-arg GIT_COMMIT=$(shell git show -s --format=%H) \
 	--build-arg GIT_COMMIT_DATE="$(shell git show -s --format=%ci)" \


### PR DESCRIPTION
This automatic PR updates ocurrences of 'registry:5000' to 'registry.internal.telnyx.com'. This change should be safe as 'registry:5000' is a pretty unique string. Double-check if any binary file has been updated